### PR TITLE
Add pushSetting method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,27 @@ $user = User::find(1);
 $theme = $user->getSetting('theme');
 ```
 
+If the setting does not exist, you can provide a default value that will be returned instead:
+```php
+$user = User::find(1);
+$theme = $user->getSetting('theme', 'light');
+```
+
+### Push a setting
+You can push a setting by calling the `pushSetting` method on your model instance. This will append the value to the existing setting that is an array. For example:
+```php
+$user = User::find(1);
+$user->pushSetting('notifications', 'email');
+```
+
+If the setting does not have an array value the method throws an exception. If for whatever reason you want convert the existing value to an array and append a value you can use the third $force parameter:
+```php
+$user = User::find(1);
+$user->pushSetting('notifications', 'email', true);
+```
+
+So if the setting is a string, it will be converted to an array and the value will be appended. If the setting is not set at all, it will be created as an array with the value.
+
 ### Deleting a setting
 You can delete a setting by calling the `deleteSetting` method on your model instance. For example:
 ```php

--- a/src/HasSettings.php
+++ b/src/HasSettings.php
@@ -5,6 +5,7 @@ namespace Kaiserkiwi\ModelSettings;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Kaiserkiwi\ModelSettings\Models\ModelSettings;
+use RuntimeException;
 
 trait HasSettings
 {
@@ -13,19 +14,34 @@ trait HasSettings
 		return $this->morphMany(ModelSettings::class, 'settingable');
 	}
 
+	/**
+	 * Get all settings for the model.
+	 */
 	public function getSettings(): Collection
 	{
 		return $this->settings()->get();
 	}
 
-	public function getSetting(string $key, $default = null): mixed
+	/**
+	 * Get a setting for the model by key.
+	 *
+	 * @param  string  $key  The key of the setting to retrieve.
+	 * @param  mixed  $default  The default value to return if the setting is not found. (Default null)
+	 */
+	public function getSetting(string $key, mixed $default = null): mixed
 	{
 		$record = $this->settings()->firstWhere('key', $key);
 
 		return $record ? $record->value : $default;
 	}
 
-	public function setSetting(string $key, $value): void
+	/**
+	 * Set a setting for the model by key.
+	 *
+	 * @param  string  $key  The key of the setting to set.
+	 * @param  mixed  $value  The value to set for the setting.
+	 */
+	public function setSetting(string $key, mixed $value): void
 	{
 		$this->settings()->updateOrCreate(
 			['key' => $key],
@@ -33,6 +49,43 @@ trait HasSettings
 		);
 	}
 
+	/**
+	 * Push a value to an array setting for the model by key.
+	 *
+	 * @param  string  $key  The key of the setting to push to.
+	 * @param  mixed  $value  The value to push to the setting.
+	 * @param  bool  $force  Whether to force the push even if the current value is not an array. (Default false)
+	 *
+	 * @throws RuntimeException
+	 */
+	public function pushSetting(string $key, mixed $value, bool $force = false): void
+	{
+		$currentValue = $this->getSetting($key);
+
+		if (is_null($currentValue)) {
+			$this->setSetting($key, [$value]);
+
+			return;
+		}
+
+		if (! is_array($currentValue)) {
+			if (! $force) {
+				throw new RuntimeException(sprintf("Cannot push to a non-array setting '%s'.", $key));
+			}
+
+			$currentValue = [$currentValue];
+		}
+
+		$currentValue[] = $value;
+
+		$this->setSetting($key, $currentValue);
+	}
+
+	/**
+	 * Remove a setting for the model by key.
+	 *
+	 * @param  string  $key  The key of the setting to remove.
+	 */
 	public function removeSetting(string $key): void
 	{
 		$this->settings()->where('key', $key)->delete();

--- a/src/Models/ModelSettings.php
+++ b/src/Models/ModelSettings.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ModelSettings extends Model
 {
-	public function getTable()
+	public function getTable(): string
 	{
 		return config('model_settings.table', 'model_settings');
 	}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,12 +6,12 @@ use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 
 class ServiceProvider extends LaravelServiceProvider
 {
-	public function register()
+	public function register(): void
 	{
 		$this->mergeConfigFrom(__DIR__ . '/../config/model_settings.php', 'model_settings');
 	}
 
-	public function boot()
+	public function boot(): void
 	{
 		if ($this->app->runningInConsole()) {
 			$this->publishes([


### PR DESCRIPTION
Closes: #1

## What was changed?
This pull request introduces the new method `pushSetting`.

## Why?
The purpose is to push another option to a setting as an array. Currently the the users of this package would've to write something like that:

```php
$user->setSetting('watched', [
	...$user->getSetting('watched') ?? [],
	'video-4',
]);
```
As this gets messy pretty fast, I wanted to have a cleaner way. The same can now be achieved with the following code:
```php
$user->pushSetting('watched', 'video-4');
```